### PR TITLE
Add instructions for Jekyll in Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,12 @@ Feel free to make a pull request, we're very open to collaboration :)
 
 ## Building MailTape locally
 
+### Using a local Jekyll install
+
 Pre-requisites:
 * Ruby 2.x.x installed (see [Installing Ruby](https://www.ruby-lang.org/en/documentation/installation/))
 
-```
+```bash
 $ gem install bundler
 $ bundle i
 $ bundle exec jekyll serve
@@ -27,3 +29,18 @@ $ bundle exec jekyll serve
 
 This serves MailTape on port 4000. Visit http://127.0.0.1:4000/ to check the
 changes you're making locally.
+
+### Using Docker
+
+If you have Docker installed, you can [run Jekyll without installing it](https://dev.to/michael/compile-a-jekyll-project-without-installing-jekyll-or-ruby-by-using-docker-4184) with the following command:
+
+```bash
+docker run --rm \
+    --volume="$PWD:/srv/jekyll" \
+    --volume="$PWD/vendor/bundle:/usr/local/bundle" \
+    --env JEKYLL_ENV=development \
+    -p 4000:4000 jekyll/jekyll:3.8 \
+    jekyll serve --incremental
+```
+
+Then visit http://127.0.0.1:4000/ as described previously.


### PR DESCRIPTION
This PR adds instructions for using Docker to run Jekyll locally without having to install it.

It helps keeping your machine clean 😉 